### PR TITLE
chore: add preview_url to community registry

### DIFF
--- a/community-modules.json
+++ b/community-modules.json
@@ -23,6 +23,7 @@
     "repo": "awbait/focus-modules",
     "download_url": "https://github.com/awbait/focus-modules/releases/download/example-counter/v1.1.0/example-counter.zip",
     "homepage": "https://github.com/awbait/focus-modules",
+    "preview_url": "https://raw.githubusercontent.com/awbait/focus-modules/main/modules/example-counter/preview.png",
     "tags": [
       "example",
       "template",


### PR DESCRIPTION
## Summary

- Добавлено поле `preview_url` для example-counter в `community-modules.json`
- Dashboard использует это поле для показа превью в модальном окне Community Modules