### PR TITLE
feat(sdk): add fm.Run entrypoint to eliminate module boilerplate

### DIFF
--- a/modules/example-counter/backend/main.go
+++ b/modules/example-counter/backend/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -11,25 +10,24 @@ import (
 	fm "github.com/awbait/focus-modules/sdk/go/focusmodule"
 )
 
-var db *sql.DB
+var (
+	db  *sql.DB
+	app *fm.App
+)
 
 func main() {
-	db = fm.OpenDB()
-	defer func() { _ = db.Close() }()
+	fm.Run(fm.Config{
+		SettingsTable: "ec_settings",
+	}, func(a *fm.App) {
+		db = a.DB
+		app = a
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /health", fm.HealthHandler)
-	mux.HandleFunc("GET /value", handleGetValue)
-	mux.HandleFunc("GET /history", handleGetHistory)
-	mux.HandleFunc("POST /increment", handleIncrement)
-	mux.HandleFunc("POST /decrement", handleDecrement)
-	mux.HandleFunc("POST /reset", handleReset)
-	mux.HandleFunc("GET /settings", handleGetSettings)
-	mux.HandleFunc("PUT /settings", handlePutSettings)
-	mux.HandleFunc("GET /widget-settings/{widgetId}", handleGetWidgetSettings)
-	mux.HandleFunc("PUT /widget-settings/{widgetId}", handlePutWidgetSettings)
-
-	fm.ListenAndServe(mux, "Example Counter")
+		a.Mux.HandleFunc("GET /value", handleGetValue)
+		a.Mux.HandleFunc("GET /history", handleGetHistory)
+		a.Mux.HandleFunc("POST /increment", handleIncrement)
+		a.Mux.HandleFunc("POST /decrement", handleDecrement)
+		a.Mux.HandleFunc("POST /reset", handleReset)
+	})
 }
 
 // --- Handlers ---
@@ -88,7 +86,7 @@ func handleGetHistory(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleIncrement(w http.ResponseWriter, r *http.Request) {
-	if !fm.RequireRole(w, r, "resident") {
+	if !fm.RequireRole(w, r, fm.RoleResident) {
 		return
 	}
 	step := parseStep(r)
@@ -96,7 +94,7 @@ func handleIncrement(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleDecrement(w http.ResponseWriter, r *http.Request) {
-	if !fm.RequireRole(w, r, "resident") {
+	if !fm.RequireRole(w, r, fm.RoleResident) {
 		return
 	}
 	step := parseStep(r)
@@ -104,7 +102,7 @@ func handleDecrement(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleReset(w http.ResponseWriter, r *http.Request) {
-	if !fm.RequireRole(w, r, "resident") {
+	if !fm.RequireRole(w, r, fm.RoleResident) {
 		return
 	}
 	var current int
@@ -119,48 +117,8 @@ func handleReset(w http.ResponseWriter, r *http.Request) {
 	if current != 0 {
 		recordHistory(0, -current)
 	}
-	fm.BroadcastEvent("example-counter", "value.changed", map[string]any{"value": 0, "delta": -current})
+	app.Broadcast("value.changed", map[string]any{"value": 0, "delta": -current})
 	fm.JSON(w, map[string]int{"value": 0, "delta": -current})
-}
-
-func handleGetSettings(w http.ResponseWriter, _ *http.Request) {
-	var raw string
-	err := db.QueryRow("SELECT value FROM ec_settings WHERE key = 'global'").Scan(&raw)
-	if err != nil {
-		fm.JSON(w, map[string]int{"step": 1})
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = fmt.Fprint(w, raw)
-}
-
-func handlePutSettings(w http.ResponseWriter, r *http.Request) {
-	if !fm.RequireRole(w, r, "owner") {
-		return
-	}
-	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		fm.HTTPError(w, http.StatusBadRequest, "invalid json")
-		return
-	}
-	data, _ := json.Marshal(body)
-	_, err := db.Exec(
-		"INSERT INTO ec_settings (key, value) VALUES ('global', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-		string(data),
-	)
-	if err != nil {
-		fm.InternalError(w, "save settings", err)
-		return
-	}
-	fm.JSON(w, map[string]bool{"ok": true})
-}
-
-func handleGetWidgetSettings(w http.ResponseWriter, _ *http.Request) {
-	handleGetSettings(w, nil)
-}
-
-func handlePutWidgetSettings(w http.ResponseWriter, r *http.Request) {
-	handlePutSettings(w, r)
 }
 
 // --- Helpers ---
@@ -187,7 +145,7 @@ func mutateValue(w http.ResponseWriter, delta int) {
 		return
 	}
 	recordHistory(newValue, delta)
-	fm.BroadcastEvent("example-counter", "value.changed", map[string]any{"value": newValue, "delta": delta})
+	app.Broadcast("value.changed", map[string]any{"value": newValue, "delta": delta})
 	fm.JSON(w, map[string]int{"value": newValue, "delta": delta})
 }
 

--- a/sdk/go/focusmodule/app.go
+++ b/sdk/go/focusmodule/app.go
@@ -1,0 +1,73 @@
+package focusmodule
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+)
+
+// App provides module access to the database, router, and manifest metadata.
+type App struct {
+	DB       *sql.DB
+	Mux      *http.ServeMux
+	Manifest Manifest
+
+	knownEvents map[string]bool
+}
+
+// Config holds optional module configuration for Run.
+type Config struct {
+	// SettingsTable is the SQLite table name for generic settings CRUD.
+	// If empty, settings routes are not registered.
+	SettingsTable string
+}
+
+// Run is the single entry point for a focus-dashboard module.
+// It reads manifest.json, opens the database, creates a mux with /health,
+// optionally registers settings routes, calls setup for custom routes,
+// and starts the HTTP server.
+func Run(cfg Config, setup func(app *App)) {
+	manifest := readManifest()
+
+	db := OpenDB()
+	defer func() { _ = db.Close() }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", HealthHandler)
+
+	if cfg.SettingsTable != "" {
+		sh := newSettingsHandler(db, cfg.SettingsTable)
+		mux.HandleFunc("GET /settings", sh.Get)
+		mux.HandleFunc("PUT /settings", sh.Put)
+		mux.HandleFunc("GET /widget-settings/{widgetId}", sh.Get)
+		mux.HandleFunc("PUT /widget-settings/{widgetId}", sh.Put)
+	}
+
+	known := make(map[string]bool, len(manifest.Events))
+	for _, e := range manifest.Events {
+		known[e.Type] = true
+	}
+
+	app := &App{
+		DB:          db,
+		Mux:         mux,
+		Manifest:    manifest,
+		knownEvents: known,
+	}
+
+	setup(app)
+
+	ListenAndServe(mux, manifest.Name)
+}
+
+// Broadcast sends a WebSocket broadcast and a domain event to the dashboard.
+// eventType is the short name (e.g. "value.changed"); the module ID prefix
+// is added automatically from manifest.json.
+// If the full event type is not declared in manifest.json events, a warning is logged.
+func (a *App) Broadcast(eventType string, payload any) {
+	fullType := a.Manifest.ID + "." + eventType
+	if !a.knownEvents[fullType] {
+		log.Printf("focusmodule: WARNING: event %q not declared in manifest.json", fullType)
+	}
+	BroadcastEvent(a.Manifest.ID, eventType, payload)
+}

--- a/sdk/go/focusmodule/manifest.go
+++ b/sdk/go/focusmodule/manifest.go
@@ -1,0 +1,46 @@
+package focusmodule
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+)
+
+// Manifest represents the module's manifest.json.
+type Manifest struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Version     string          `json:"version"`
+	Author      string          `json:"author"`
+	Events      []ManifestEvent `json:"events"`
+}
+
+// ManifestEvent describes an event declared in manifest.json.
+type ManifestEvent struct {
+	Type        string            `json:"type"`
+	Description string            `json:"description"`
+	Payload     map[string]string `json:"payload"`
+}
+
+// readManifest reads and parses ./manifest.json from the current working directory.
+func readManifest() Manifest {
+	data, err := os.ReadFile("manifest.json")
+	if err != nil {
+		log.Fatalf("focusmodule: read manifest.json: %v", err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		log.Fatalf("focusmodule: parse manifest.json: %v", err)
+	}
+
+	if m.ID == "" {
+		log.Fatal("focusmodule: manifest.json: id is required")
+	}
+	if m.Name == "" {
+		log.Fatal("focusmodule: manifest.json: name is required")
+	}
+
+	return m
+}

--- a/sdk/go/focusmodule/module.go
+++ b/sdk/go/focusmodule/module.go
@@ -2,16 +2,21 @@
 //
 // A typical module main.go:
 //
+//	var db *sql.DB
+//	var app *focusmodule.App
+//
 //	func main() {
-//	    db := focusmodule.OpenDB()
-//	    defer db.Close()
-//
-//	    mux := http.NewServeMux()
-//	    mux.HandleFunc("GET /health", focusmodule.HealthHandler)
-//	    // ... your routes ...
-//
-//	    focusmodule.ListenAndServe(mux, "My Module")
+//	    focusmodule.Run(focusmodule.Config{
+//	        SettingsTable: "my_settings", // optional
+//	    }, func(a *focusmodule.App) {
+//	        db = a.DB
+//	        app = a
+//	        a.Mux.HandleFunc("GET /data", handleData)
+//	    })
 //	}
+//
+// Run reads manifest.json, opens the database, registers /health and
+// optional settings routes, then starts the HTTP server.
 package focusmodule
 
 import (

--- a/sdk/go/focusmodule/rbac.go
+++ b/sdk/go/focusmodule/rbac.go
@@ -5,14 +5,21 @@ import (
 	"net/http"
 )
 
+// Role constants for use with RequireRole.
+const (
+	RoleGuest    = "guest"
+	RoleResident = "resident"
+	RoleOwner    = "owner"
+)
+
 // Role hierarchy: guest < resident < owner.
-var roleLevel = map[string]int{"guest": 0, "resident": 1, "owner": 2}
+var roleLevel = map[string]int{RoleGuest: 0, RoleResident: 1, RoleOwner: 2}
 
 // RequireRole checks the X-Focus-User-Role header injected by the dashboard proxy.
 // Returns false and writes 403 if the caller lacks the required role.
 //
 //	func handleDelete(w http.ResponseWriter, r *http.Request) {
-//	    if !focusmodule.RequireRole(w, r, "owner") {
+//	    if !focusmodule.RequireRole(w, r, focusmodule.RoleOwner) {
 //	        return
 //	    }
 //	    // ...
@@ -20,7 +27,7 @@ var roleLevel = map[string]int{"guest": 0, "resident": 1, "owner": 2}
 func RequireRole(w http.ResponseWriter, r *http.Request, required string) bool {
 	role := r.Header.Get("X-Focus-User-Role")
 	if role == "" {
-		role = "guest"
+		role = RoleGuest
 	}
 	if roleLevel[role] < roleLevel[required] {
 		HTTPError(w, http.StatusForbidden, fmt.Sprintf("forbidden: requires %s", required))
@@ -34,7 +41,7 @@ func RequireRole(w http.ResponseWriter, r *http.Request, required string) bool {
 func UserRole(r *http.Request) string {
 	role := r.Header.Get("X-Focus-User-Role")
 	if role == "" {
-		return "guest"
+		return RoleGuest
 	}
 	return role
 }

--- a/sdk/go/focusmodule/settings.go
+++ b/sdk/go/focusmodule/settings.go
@@ -1,0 +1,61 @@
+package focusmodule
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// settingsHandler provides generic JSON settings CRUD for a module.
+// It stores settings as a raw JSON blob in the given table with schema:
+//
+//	CREATE TABLE <table> (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+type settingsHandler struct {
+	db    *sql.DB
+	table string
+}
+
+func newSettingsHandler(db *sql.DB, table string) *settingsHandler {
+	return &settingsHandler{db: db, table: table}
+}
+
+// Get returns the settings JSON from the database.
+// If no record exists, it returns {}.
+func (s *settingsHandler) Get(w http.ResponseWriter, _ *http.Request) {
+	var raw string
+	query := fmt.Sprintf("SELECT value FROM %s WHERE key = 'global'", s.table)
+	err := s.db.QueryRow(query).Scan(&raw)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, "{}")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprint(w, raw)
+}
+
+// Put saves settings as a JSON blob. Requires the "owner" role.
+func (s *settingsHandler) Put(w http.ResponseWriter, r *http.Request) {
+	if !RequireRole(w, r, RoleOwner) {
+		return
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		HTTPError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+
+	data, _ := json.Marshal(body)
+	query := fmt.Sprintf(
+		"INSERT INTO %s (key, value) VALUES ('global', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+		s.table,
+	)
+	if _, err := s.db.Exec(query, string(data)); err != nil {
+		InternalError(w, "save settings", err)
+		return
+	}
+
+	JSON(w, map[string]bool{"ok": true})
+}


### PR DESCRIPTION
## Summary

- Add `fm.Run()` — single entrypoint for modules that handles DB, mux, `/health`, settings routes, and server startup
- Add `manifest.go` — SDK reads `manifest.json` at startup, no more hardcoded name/id in code
- Add `settings.go` — generic settings CRUD moved to SDK, modules don't copy-paste it
- Add `App.Broadcast()` — uses module ID from manifest, validates event types against `manifest.json`
- Add role constants (`RoleGuest`, `RoleResident`, `RoleOwner`) to replace magic strings
- Migrate `example-counter` to `fm.Run`, removing ~40 lines of boilerplate

## Test plan

- [ ] Build SDK: `cd sdk/go/focusmodule && go vet ./...`
- [ ] Build example-counter: `cd modules/example-counter/backend && go vet ./...`
- [ ] Run example-counter and verify `/health`, `/settings`, `/widget-settings/{id}` work
- [ ] Verify `app.Broadcast()` logs warning for undeclared event types

Fixes #15