### PR TITLE
feat(sdk-types): add registerWidget, usePermission, baseStyles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,23 @@
         "lefthook": "^1.11.13",
       },
     },
+    "modules/example-counter/frontend": {
+      "name": "example-counter-frontend",
+      "devDependencies": {
+        "@focus-dashboard/sdk-types": "workspace:*",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "^5.7.0",
+      },
+    },
+    "sdk/ts/sdk-types": {
+      "name": "@focus-dashboard/sdk-types",
+      "version": "0.4.0",
+      "devDependencies": {
+        "@types/react": ">=18",
+        "@types/react-dom": ">=18",
+      },
+    },
   },
   "packages": {
     "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
@@ -30,6 +47,12 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
 
+    "@focus-dashboard/sdk-types": ["@focus-dashboard/sdk-types@workspace:sdk/ts/sdk-types"],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-cli": ["ajv-cli@5.0.0", "", { "dependencies": { "ajv": "^8.0.0", "fast-json-patch": "^2.0.0", "glob": "^7.1.0", "js-yaml": "^3.14.0", "json-schema-migrate": "^2.0.0", "json5": "^2.1.3", "minimist": "^1.2.0" }, "peerDependencies": { "ts-node": ">=9.0.0" }, "optionalPeers": ["ts-node"], "bin": { "ajv": "dist/index.js" } }, "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ=="],
@@ -42,7 +65,11 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "example-counter-frontend": ["example-counter-frontend@workspace:modules/example-counter/frontend"],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -99,6 +126,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 

--- a/modules/example-counter/frontend/bun.lock
+++ b/modules/example-counter/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "example-counter-frontend",
       "devDependencies": {
-        "@focus-dashboard/sdk-types": "^0.3.0",
+        "@focus-dashboard/sdk-types": "link:../../../sdk/ts/sdk-types",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "typescript": "^5.7.0",
@@ -13,7 +13,7 @@
     },
   },
   "packages": {
-    "@focus-dashboard/sdk-types": ["@focus-dashboard/sdk-types@0.3.0", "", {}, "sha512-olLdm4j7qMLklUoGF8wWwSbyAzTalxYZiOCvvPb3ix7DZB+Pb4bkQ8bpwSEdFoc+oVAi6EtyAQ0uHwM6nfcYVg=="],
+    "@focus-dashboard/sdk-types": ["@focus-dashboard/sdk-types@link:../../../sdk/ts/sdk-types", {}],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 

--- a/modules/example-counter/frontend/package.json
+++ b/modules/example-counter/frontend/package.json
@@ -6,7 +6,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@focus-dashboard/sdk-types": "^0.3.0",
+    "@focus-dashboard/sdk-types": "^0.5.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.7.0"

--- a/modules/example-counter/frontend/src/chart-widget.tsx
+++ b/modules/example-counter/frontend/src/chart-widget.tsx
@@ -1,7 +1,6 @@
+import { baseStyles, registerWidget } from '@focus-dashboard/sdk-types'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { createRoot } from 'react-dom/client'
 import type { HistoryEntry, Styles, WidgetProps } from './types'
-import { ReactWidgetElement } from './types'
 
 function ChartApp({ focus }: WidgetProps) {
   const [history, setHistory] = useState<HistoryEntry[]>([])
@@ -126,11 +125,10 @@ function LineChart({ history }: LineChartProps) {
 
 const styles: Styles = {
   container: {
+    ...baseStyles.widget,
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
-    fontFamily: 'var(--font-sans, system-ui, -apple-system, sans-serif)',
-    color: 'var(--foreground)',
   },
   header: {
     fontSize: '0.875rem',
@@ -153,12 +151,4 @@ const styles: Styles = {
   },
 }
 
-class ExampleCounterChartWidget extends ReactWidgetElement {
-  connectedCallback() {
-    const focus = window.FocusSDK.create(this)
-    this._root = createRoot(this)
-    this._root.render(<ChartApp focus={focus} />)
-  }
-}
-
-customElements.define('example-counter-chart-widget', ExampleCounterChartWidget)
+registerWidget('example-counter-chart-widget', ChartApp)

--- a/modules/example-counter/frontend/src/counter-widget.tsx
+++ b/modules/example-counter/frontend/src/counter-widget.tsx
@@ -1,23 +1,13 @@
+import { baseStyles, registerWidget, usePermission } from '@focus-dashboard/sdk-types'
 import React, { useCallback, useEffect, useState } from 'react'
-import { createRoot } from 'react-dom/client'
 import type { Styles, ValueResponse, WidgetProps, WidgetSettings } from './types'
-import { ReactWidgetElement } from './types'
 
 function CounterApp({ focus }: WidgetProps) {
   const [value, setValue] = useState(0)
   const [step, setStep] = useState(1)
-  const [canWrite, setCanWrite] = useState(false)
-
-  const checkPermission = useCallback(() => {
-    focus
-      .can('write')
-      .then(setCanWrite)
-      .catch(() => setCanWrite(false))
-  }, [focus])
+  const canWrite = usePermission(focus, 'write')
 
   useEffect(() => {
-    checkPermission()
-
     focus
       .getSettings<WidgetSettings>()
       .then((s) => {
@@ -37,26 +27,11 @@ function CounterApp({ focus }: WidgetProps) {
 
     focus.ready()
     return unsub
-  }, [focus, checkPermission])
-
-  // Instant disable on logout; re-check on window focus (other tabs).
-  useEffect(() => {
-    const onLogout = () => setCanWrite(false)
-    const onFocus = () => checkPermission()
-    window.addEventListener('auth:unauthorized', onLogout)
-    window.addEventListener('focus', onFocus)
-    return () => {
-      window.removeEventListener('auth:unauthorized', onLogout)
-      window.removeEventListener('focus', onFocus)
-    }
-  }, [checkPermission])
+  }, [focus])
 
   const guardedAction = useCallback((action: () => Promise<void>) => {
     return () => {
       action().catch((err: Error) => {
-        if (err.message.includes('403') || err.message.includes('401')) {
-          setCanWrite(false)
-        }
         console.error('example-counter:', err)
       })
     }
@@ -111,14 +86,13 @@ function CounterApp({ focus }: WidgetProps) {
 
 const styles: Styles = {
   container: {
+    ...baseStyles.widget,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
     height: '100%',
     gap: '12px',
-    fontFamily: 'var(--font-sans, system-ui, -apple-system, sans-serif)',
-    color: 'var(--foreground)',
   },
   value: {
     fontSize: '3rem',
@@ -156,19 +130,7 @@ const styles: Styles = {
     color: 'var(--primary-foreground)',
     border: '1px solid transparent',
   },
-  disabled: {
-    opacity: 0.5,
-    cursor: 'not-allowed',
-    pointerEvents: 'none' as const,
-  },
+  disabled: baseStyles.disabled,
 }
 
-class ExampleCounterCounterWidget extends ReactWidgetElement {
-  connectedCallback() {
-    const focus = window.FocusSDK.create(this)
-    this._root = createRoot(this)
-    this._root.render(<CounterApp focus={focus} />)
-  }
-}
-
-customElements.define('example-counter-counter-widget', ExampleCounterCounterWidget)
+registerWidget('example-counter-counter-widget', CounterApp)

--- a/modules/example-counter/frontend/src/settings.tsx
+++ b/modules/example-counter/frontend/src/settings.tsx
@@ -1,29 +1,20 @@
+import type { FocusInstance } from '@focus-dashboard/sdk-types'
+import { baseStyles, registerWidget, usePermission } from '@focus-dashboard/sdk-types'
 import React, { useEffect, useState } from 'react'
-import { createRoot } from 'react-dom/client'
-import type { FocusInstance, Styles, WidgetSettings } from './types'
-import { ReactWidgetElement } from './types'
+import type { Styles, WidgetSettings } from './types'
 
 function SettingsApp({ focus }: { focus: FocusInstance }) {
   const [step, setStep] = useState(1)
   const [saved, setSaved] = useState(false)
-  const [canAdmin, setCanAdmin] = useState(false)
+  const canAdmin = usePermission(focus, 'admin')
 
   useEffect(() => {
-    focus
-      .can('admin')
-      .then(setCanAdmin)
-      .catch(() => setCanAdmin(false))
-
     focus
       .api<WidgetSettings>('GET', '/settings')
       .then((s) => {
         if (s?.step > 0) setStep(s.step)
       })
       .catch(() => {})
-
-    const onLogout = () => setCanAdmin(false)
-    window.addEventListener('auth:unauthorized', onLogout)
-    return () => window.removeEventListener('auth:unauthorized', onLogout)
   }, [focus])
 
   const save = () => {
@@ -68,12 +59,11 @@ function SettingsApp({ focus }: { focus: FocusInstance }) {
 
 const styles: Styles = {
   container: {
+    ...baseStyles.widget,
     display: 'flex',
     flexDirection: 'column',
     gap: '16px',
     padding: '8px 0',
-    fontFamily: 'var(--font-sans, system-ui, -apple-system, sans-serif)',
-    color: 'var(--foreground)',
   },
   field: {
     display: 'flex',
@@ -121,19 +111,7 @@ const styles: Styles = {
     fontSize: '0.75rem',
     color: 'var(--primary)',
   },
-  disabled: {
-    opacity: 0.5,
-    cursor: 'not-allowed',
-    pointerEvents: 'none' as const,
-  },
+  disabled: baseStyles.disabled,
 }
 
-class ExampleCounterSettings extends ReactWidgetElement {
-  connectedCallback() {
-    const focus = window.FocusSDK.create(this)
-    this._root = createRoot(this)
-    this._root.render(<SettingsApp focus={focus} />)
-  }
-}
-
-customElements.define('example-counter-settings', ExampleCounterSettings)
+registerWidget('example-counter-settings', SettingsApp)

--- a/modules/example-counter/frontend/src/types.ts
+++ b/modules/example-counter/frontend/src/types.ts
@@ -1,27 +1,9 @@
-import type { Root } from 'react-dom/client'
-
 export type {
   FocusInstance,
   FocusSDKGlobal,
   Styles,
   WidgetProps,
 } from '@focus-dashboard/sdk-types'
-
-// ---------------------------------------------------------------------------
-// ReactWidgetElement — base class for custom element wrappers.
-// Will move to @focus-dashboard/sdk-types in v0.4.0.
-// ---------------------------------------------------------------------------
-
-export class ReactWidgetElement extends HTMLElement {
-  _root: Root | null = null
-
-  disconnectedCallback() {
-    if (this._root) {
-      this._root.unmount()
-      this._root = null
-    }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Module-specific types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "focus-modules",
   "private": true,
+  "workspaces": [
+    "sdk/ts/*",
+    "modules/*/frontend"
+  ],
   "scripts": {
     "lint": "biome check",
     "lint:fix": "biome check --fix",

--- a/sdk/ts/sdk-types/package.json
+++ b/sdk/ts/sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@focus-dashboard/sdk-types",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript types and base classes for Focus Dashboard dynamic modules",
   "license": "MIT",
   "author": "awbait",
@@ -8,7 +8,9 @@
   "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./globals": {
       "types": "./src/globals.d.ts"

--- a/sdk/ts/sdk-types/src/index.ts
+++ b/sdk/ts/sdk-types/src/index.ts
@@ -1,4 +1,6 @@
 import type { CSSProperties } from 'react'
+import { createElement, useCallback, useEffect, useState } from 'react'
+import { createRoot } from 'react-dom/client'
 
 // ---------------------------------------------------------------------------
 // Core SDK interfaces
@@ -92,19 +94,8 @@ export type Styles = Record<string, CSSProperties>
 /**
  * Base class for React-powered custom elements.
  *
- * Handles React root lifecycle (unmount on disconnect). Subclass and
- * implement `connectedCallback()` to create the root and render:
- *
- * ```ts
- * class MyWidget extends ReactWidgetElement {
- *   connectedCallback() {
- *     const focus = window.FocusSDK.create(this)
- *     this._root = createRoot(this)
- *     this._root.render(<App focus={focus} />)
- *   }
- * }
- * customElements.define('my-module-widget', MyWidget)
- * ```
+ * Handles React root lifecycle (unmount on disconnect).
+ * Prefer using {@link registerWidget} instead of subclassing directly.
  */
 export class ReactWidgetElement extends HTMLElement {
   _root: import('react-dom/client').Root | null = null
@@ -116,3 +107,89 @@ export class ReactWidgetElement extends HTMLElement {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// registerWidget — one-line widget registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a React component as a custom element widget.
+ *
+ * Handles FocusSDK initialization, React root creation, and cleanup.
+ *
+ * ```ts
+ * registerWidget('my-module-counter', CounterApp)
+ * registerWidget('my-module-settings', SettingsApp)
+ * ```
+ */
+export function registerWidget(tagName: string, Component: (props: WidgetProps) => any) {
+  const Cls = class extends ReactWidgetElement {
+    connectedCallback() {
+      const focus = (window as any).FocusSDK.create(this)
+      this._root = createRoot(this)
+      this._root.render(createElement(Component, { focus }))
+    }
+  }
+  customElements.define(tagName, Cls)
+}
+
+// ---------------------------------------------------------------------------
+// usePermission — reactive permission check hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Reactive permission check. Returns `true` if the current user has
+ * the required permission level. Automatically resets on logout
+ * (`auth:unauthorized` event) and re-checks on window focus.
+ *
+ * ```tsx
+ * const canWrite = usePermission(focus, 'write')
+ * const canAdmin = usePermission(focus, 'admin')
+ * ```
+ */
+export function usePermission(focus: FocusInstance, action: FocusAction): boolean {
+  const [allowed, setAllowed] = useState(false)
+
+  const check = useCallback(() => {
+    focus
+      .can(action)
+      .then(setAllowed)
+      .catch(() => setAllowed(false))
+  }, [focus, action])
+
+  useEffect(() => {
+    check()
+  }, [check])
+
+  useEffect(() => {
+    const onLogout = () => setAllowed(false)
+    const onFocus = () => check()
+    window.addEventListener('auth:unauthorized', onLogout)
+    window.addEventListener('focus', onFocus)
+    return () => {
+      window.removeEventListener('auth:unauthorized', onLogout)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [check])
+
+  return allowed
+}
+
+// ---------------------------------------------------------------------------
+// baseStyles — shared widget styles
+// ---------------------------------------------------------------------------
+
+/** Base styles shared across all widgets. */
+export const baseStyles = {
+  /** Common widget container: font family and text color. */
+  widget: {
+    fontFamily: 'var(--font-sans, system-ui, -apple-system, sans-serif)',
+    color: 'var(--foreground)',
+  },
+  /** Disabled state for interactive elements. */
+  disabled: {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+    pointerEvents: 'none' as const,
+  },
+} satisfies Record<string, CSSProperties>


### PR DESCRIPTION
## Summary

- **`registerWidget(tagName, Component)`** — 1 строка вместо 7 для регистрации custom element виджета
- **`usePermission(focus, action)`** — реактивная проверка прав с auto-reset на logout и recheck на window focus (1 строка вместо ~20)
- **`baseStyles.widget` / `baseStyles.disabled`** — общие CSS-стили, убирают дублирование между виджетами
- **Bun workspaces** — SDK резолвится локально для разработки
- **sdk-types v0.5.0** — добавлены `import`/`default` export conditions (был только `types`)
- Удалён дубликат `ReactWidgetElement` из example-counter
- Мигрированы все 3 виджета example-counter на новые хелперы

## Test plan

- [ ] `cd modules/example-counter/frontend && bunx tsc --noEmit`
- [ ] `cd modules/example-counter/frontend && bun run build`
- [ ] Проверить counter widget: кнопки +/- работают, disabled при отсутствии прав
- [ ] Проверить settings: сохранение step, disabled для не-owner
- [ ] Проверить chart widget: обновление при value.changed

Fixes #18, fixes #19, fixes #20, fixes #22