### PR TITLE
fix(ci): exclude sdk-types from release-module workflow

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check latest releases and update versions
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: Biome (TypeScript)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
 
@@ -31,9 +31,9 @@ jobs:
           - sdk/go/focusmodule
           - modules/example-counter/backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.directory }}/go.mod
 

--- a/.github/workflows/publish-sdk-types.yml
+++ b/.github/workflows/publish-sdk-types.yml
@@ -12,7 +12,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release-module.yml
+++ b/.github/workflows/release-module.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Parse tag
         id: meta
@@ -38,7 +38,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ steps.meta.outputs.module_dir }}/backend/go.mod
 


### PR DESCRIPTION
## Summary

- Тег `sdk-types/v0.5.0` триггерил `release-module.yml` (паттерн `*/v*`), который ожидает `modules/sdk-types` — падал с ошибкой
- Добавлен `!sdk-types/v*` exclusion — SDK релизы обрабатываются `publish-sdk-types.yml`