### PR TITLE
refactor(build): replace React shim plugin with external imports

### DIFF
--- a/modules/example-counter/frontend/build.ts
+++ b/modules/example-counter/frontend/build.ts
@@ -1,83 +1,30 @@
 /**
  * Build script for example-counter module.
  *
- * Bundles TSX sources into widget.js and settings.js that use window.React
- * and window.ReactDOM at runtime (provided by the host app).
+ * React/ReactDOM are marked as external — the host app provides them
+ * via an import map, so the browser resolves bare specifiers at runtime.
  */
 
-const REACT_SHIM = `
-const React = window.React;
-const {createElement, Fragment, useState, useEffect, useCallback, useMemo, useRef} = React;
-export default React;
-export {createElement, Fragment, useState, useEffect, useCallback, useMemo, useRef};
-`
+const external = ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime']
 
-const REACT_DOM_SHIM = `
-const ReactDOM = window.ReactDOM;
-export const createRoot = ReactDOM.createRoot;
-export default ReactDOM;
-`
+async function bundle(entrypoint: string, outName: string) {
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    outdir: 'dist',
+    naming: outName,
+    format: 'esm',
+    target: 'browser',
+    minify: false,
+    external,
+  })
 
-const reactGlobalsPlugin = {
-  name: 'react-globals',
-  setup(build: any) {
-    build.onResolve({ filter: /^react$/ }, () => ({
-      path: 'react',
-      namespace: 'react-shim',
-    }))
-    build.onLoad({ filter: /.*/, namespace: 'react-shim' }, () => ({
-      contents: REACT_SHIM,
-      loader: 'js',
-    }))
-
-    build.onResolve({ filter: /^react-dom\/client$/ }, () => ({
-      path: 'react-dom/client',
-      namespace: 'react-dom-shim',
-    }))
-    build.onLoad({ filter: /.*/, namespace: 'react-dom-shim' }, () => ({
-      contents: REACT_DOM_SHIM,
-      loader: 'js',
-    }))
-
-    build.onResolve({ filter: /^react-dom$/ }, () => ({
-      path: 'react-dom',
-      namespace: 'react-dom-shim',
-    }))
-  },
+  if (!result.success) {
+    console.error(`${outName} build failed:`)
+    for (const msg of result.logs) console.error(msg)
+    process.exit(1)
+  }
+  console.log(`  -> ${outName} built (${(result.outputs[0].size / 1024).toFixed(1)} KB)`)
 }
 
-// Build widget.js
-const widgetResult = await Bun.build({
-  entrypoints: ['src/index.ts'],
-  outdir: 'dist',
-  naming: 'widget.js',
-  format: 'esm',
-  target: 'browser',
-  minify: false,
-  plugins: [reactGlobalsPlugin],
-})
-
-if (!widgetResult.success) {
-  console.error('widget.js build failed:')
-  for (const msg of widgetResult.logs) console.error(msg)
-  process.exit(1)
-}
-console.log(`  -> widget.js built (${(widgetResult.outputs[0].size / 1024).toFixed(1)} KB)`)
-
-// Build settings.js
-const settingsResult = await Bun.build({
-  entrypoints: ['src/settings.tsx'],
-  outdir: 'dist',
-  naming: 'settings.js',
-  format: 'esm',
-  target: 'browser',
-  minify: false,
-  plugins: [reactGlobalsPlugin],
-})
-
-if (!settingsResult.success) {
-  console.error('settings.js build failed:')
-  for (const msg of settingsResult.logs) console.error(msg)
-  process.exit(1)
-}
-console.log(`  -> settings.js built (${(settingsResult.outputs[0].size / 1024).toFixed(1)} KB)`)
+await bundle('src/index.ts', 'widget.js')
+await bundle('src/settings.tsx', 'settings.js')


### PR DESCRIPTION
## Summary
- Убран `reactGlobalsPlugin` (шим для `window.React`/`window.ReactDOM`) из `build.ts`
- React/ReactDOM помечены как `external` — браузер резолвит через import map хост-приложения
- Два вызова `Bun.build` объединены в функцию `bundle()`
- 76 строк удалено, 23 добавлено

Зависит от focus-dashboard#84 (import map).

Refs #17

## Test plan
- [ ] `bun run build` проходит без ошибок
- [ ] В выходных файлах `import ... from "react"` сохраняется как bare specifier
- [ ] Модуль работает в дашборде после деплоя import map