### PR TITLE
chore: убрать дублирование формата из CHANGELOG-ов

### DIFF
--- a/modules/example-counter/CHANGELOG.md
+++ b/modules/example-counter/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 Все заметные изменения в модуле `example-counter` документируются в этом файле.
 
-Формат основан на [Keep a Changelog](https://keepachangelog.com/ru/1.1.0/).
-
 ## [Unreleased]
 
 ### Changed

--- a/sdk/go/focusmodule/CHANGELOG.md
+++ b/sdk/go/focusmodule/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 Все заметные изменения в Go SDK (`focusmodule`) документируются в этом файле.
 
-Формат основан на [Keep a Changelog](https://keepachangelog.com/ru/1.1.0/).
-
 ## [Unreleased]
 
 ## [0.1.0] - 2026-04-01

--- a/sdk/ts/sdk-types/CHANGELOG.md
+++ b/sdk/ts/sdk-types/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 Все заметные изменения в `@focus-dashboard/sdk-types` документируются в этом файле.
 
-Формат основан на [Keep a Changelog](https://keepachangelog.com/ru/1.1.0/).
-
 ## [Unreleased]
 
 ## [0.7.0] - 2026-04-01


### PR DESCRIPTION
Убрана строка «Формат основан на Keep a Changelog» из каждого CHANGELOG — она уже описана в RELEASING.md.