### PR TITLE
release: example-counter v1.2.0

### DIFF
--- a/modules/example-counter/CHANGELOG.md
+++ b/modules/example-counter/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-01
+
 ### Changed
 - Бэкенд использует `fm.Run()` из Go SDK (убран boilerplate)
 - Фронтенд использует `registerWidget`, `usePermission`, `baseStyles` из sdk-types


### PR DESCRIPTION
## Changes
- Бэкенд использует `fm.Run()` из Go SDK (убран boilerplate)
- Фронтенд использует `registerWidget`, `usePermission`, `baseStyles` из sdk-types
- Сборка через `focus-build` (build.ts удалён)
- React подключается через import map хоста (убран shim plugin)

После мержа — поставить тег `example-counter/v1.2.0` на merge-коммит.