### PR TITLE
chore: update pill-tracker to v1.1.1

### DIFF
--- a/community-modules.json
+++ b/community-modules.json
@@ -35,9 +35,9 @@
     "name": "Pill Tracker",
     "author": "awbait",
     "description": "Track medication intake for humans and animals: patients, prescriptions, schedules, dose logging",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "repo": "awbait/focus-modules",
-    "download_url": "https://github.com/awbait/focus-modules/releases/download/pill-tracker/v1.0.0/pill-tracker.zip",
+    "download_url": "https://github.com/awbait/focus-modules/releases/download/pill-tracker/v1.1.1/pill-tracker.zip",
     "homepage": "https://github.com/awbait/focus-modules",
     "tags": [
       "health",


### PR DESCRIPTION
Update community-modules.json after pill-tracker v1.1.1 release (CI missed due to branch protection bug, now fixed).