### PR TITLE
release: sdk-types v0.10.0

### DIFF
--- a/sdk/ts/sdk-types/CHANGELOG.md
+++ b/sdk/ts/sdk-types/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-04
+
+### Added
+- `DashboardConfig` интерфейс — настройки дашборда (timezone, dateFormat, timeFormat, language)
+- `getDashboardConfig()` метод в `FocusInstance` — синхронный доступ к глобальным настройкам дашборда
+
 ## [0.9.0] - 2026-04-03
 
 ### Added

--- a/sdk/ts/sdk-types/package.json
+++ b/sdk/ts/sdk-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@focus-dashboard/sdk-types",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript types and base classes for Focus Dashboard dynamic modules",
   "license": "MIT",
   "author": "awbait",


### PR DESCRIPTION
## Summary

- `DashboardConfig` интерфейс (timezone, dateFormat, timeFormat, language)
- `getDashboardConfig()` метод в `FocusInstance`

CHANGELOG и package.json обновлены. После мержа — тег `sdk-types/v0.10.0`.