### PR TITLE
feat(pill-tracker): use SDK dashboard config for dates and timezone

### DIFF
--- a/modules/pill-tracker/backend/main.go
+++ b/modules/pill-tracker/backend/main.go
@@ -425,7 +425,7 @@ func handleCreatePrescription(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if req.StartDate == "" {
-		req.StartDate = time.Now().Format("2006-01-02")
+		req.StartDate = time.Now().Format("2006-01-02") // UTC fallback; frontend should always provide date
 	}
 	if req.MealRelation == "" {
 		req.MealRelation = "none"
@@ -773,7 +773,13 @@ func handleToday(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetDate := time.Now().Format("2006-01-02")
+	now := time.Now()
+	if tz := r.URL.Query().Get("tz"); tz != "" {
+		if loc, err := time.LoadLocation(tz); err == nil {
+			now = now.In(loc)
+		}
+	}
+	targetDate := now.Format("2006-01-02")
 	if d := r.URL.Query().Get("date"); d != "" {
 		parsed, err := time.Parse("2006-01-02", d)
 		if err != nil {

--- a/modules/pill-tracker/frontend/src/components/ui/date-input.tsx
+++ b/modules/pill-tracker/frontend/src/components/ui/date-input.tsx
@@ -13,6 +13,8 @@ interface DateInputProps {
   placeholder?: string
   className?: string
   clearable?: boolean
+  /** date-fns display format, e.g. "dd.MM.yyyy". Defaults to "dd.MM.yyyy". */
+  displayFormat?: string
 }
 
 /** Format Date → YYYY-MM-DD string */
@@ -30,7 +32,14 @@ function parseDate(s: string): Date | undefined {
   return parse(s, 'yyyy-MM-dd', new Date())
 }
 
-function DateInput({ value, onChange, placeholder, className, clearable }: DateInputProps) {
+function DateInput({
+  value,
+  onChange,
+  placeholder,
+  className,
+  clearable,
+  displayFormat = 'dd.MM.yyyy',
+}: DateInputProps) {
   const [open, setOpen] = React.useState(false)
   const selected = parseDate(value)
 
@@ -47,7 +56,7 @@ function DateInput({ value, onChange, placeholder, className, clearable }: DateI
             )}
           >
             <CalendarIcon className="size-4 mr-2 shrink-0" />
-            {selected ? format(selected, 'dd.MM.yyyy') : placeholder || 'дд.мм.гггг'}
+            {selected ? format(selected, displayFormat) : placeholder || 'дд.мм.гггг'}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">

--- a/modules/pill-tracker/frontend/src/lib/format-utils.ts
+++ b/modules/pill-tracker/frontend/src/lib/format-utils.ts
@@ -1,0 +1,75 @@
+import type { FocusInstance } from '@focus-dashboard/sdk-types'
+
+/** Mapping from SDK dateFormat to date-fns format tokens. */
+const DATE_FORMAT_MAP: Record<string, string> = {
+  'DD.MM.YYYY': 'dd.MM.yyyy',
+  'MM/DD/YYYY': 'MM/dd/yyyy',
+  'YYYY-MM-DD': 'yyyy-MM-dd',
+}
+
+/** Short variant (without full year). */
+const DATE_FORMAT_SHORT_MAP: Record<string, string> = {
+  'DD.MM.YYYY': 'dd.MM.yy',
+  'MM/DD/YYYY': 'MM/dd/yy',
+  'YYYY-MM-DD': 'yy-MM-dd',
+}
+
+/** Get date-fns format string from SDK config. */
+export function getDateFnsFormat(sdkFormat: string): string {
+  return DATE_FORMAT_MAP[sdkFormat] ?? 'dd.MM.yyyy'
+}
+
+/** Get short date-fns format string from SDK config. */
+export function getDateFnsShortFormat(sdkFormat: string): string {
+  return DATE_FORMAT_SHORT_MAP[sdkFormat] ?? 'dd.MM.yy'
+}
+
+/**
+ * Get "now" in the dashboard timezone as a Date object.
+ * Uses Intl to extract date parts in the configured timezone,
+ * then constructs a local Date representing that calendar date/time.
+ */
+export function nowInTimezone(focus: FocusInstance): Date {
+  const tz = focus.getDashboardConfig().timezone
+  const now = new Date()
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(now)
+
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '0'
+  return new Date(
+    Number(get('year')),
+    Number(get('month')) - 1,
+    Number(get('day')),
+    Number(get('hour')),
+    Number(get('minute')),
+    Number(get('second')),
+  )
+}
+
+/**
+ * Format a time string (HH:MM from ISO) respecting 12h/24h preference.
+ * Input: "14:30" or full ISO "2026-04-05T14:30:00Z"
+ */
+export function formatTime(timeOrIso: string, focus: FocusInstance): string {
+  const hhmm = timeOrIso.includes('T') ? timeOrIso.slice(11, 16) : timeOrIso
+  const { timeFormat } = focus.getDashboardConfig()
+
+  if (timeFormat === '12h') {
+    const [hStr, mStr] = hhmm.split(':')
+    let h = Number(hStr)
+    const suffix = h >= 12 ? 'PM' : 'AM'
+    if (h === 0) h = 12
+    else if (h > 12) h -= 12
+    return `${h}:${mStr} ${suffix}`
+  }
+
+  return hhmm
+}

--- a/modules/pill-tracker/frontend/src/settings.tsx
+++ b/modules/pill-tracker/frontend/src/settings.tsx
@@ -53,7 +53,7 @@ import {
   SelectValue,
 } from './components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs'
-import { getDateFnsFormat, getDateFnsShortFormat } from './lib/format-utils'
+import { formatTime, getDateFnsFormat, getDateFnsShortFormat } from './lib/format-utils'
 import { cn } from './lib/utils'
 import type {
   FocusPublicUser,
@@ -574,7 +574,7 @@ function PatientDetailView({
                           size={12}
                           className="text-muted-foreground shrink-0"
                         />
-                        <span className="font-medium">{s.time}</span>
+                        <span className="font-medium">{formatTime(s.time, focus)}</span>
                         <span className="text-muted-foreground truncate">
                           {frequencyLabel(s, t)}
                         </span>

--- a/modules/pill-tracker/frontend/src/settings.tsx
+++ b/modules/pill-tracker/frontend/src/settings.tsx
@@ -53,6 +53,7 @@ import {
   SelectValue,
 } from './components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs'
+import { getDateFnsFormat, getDateFnsShortFormat } from './lib/format-utils'
 import { cn } from './lib/utils'
 import type {
   FocusPublicUser,
@@ -538,7 +539,10 @@ function PatientDetailView({
                           {t(`settings.${p.status}`)}
                         </Badge>
                         <span className="inline-flex items-center gap-1">
-                          {format(parseISO(p.start_date), 'dd.MM.yy')}
+                          {format(
+                            parseISO(p.start_date),
+                            getDateFnsShortFormat(focus.getDashboardConfig().dateFormat),
+                          )}
                           {p.end_date && (
                             <>
                               <HugeiconsIcon
@@ -546,7 +550,10 @@ function PatientDetailView({
                                 size={12}
                                 className="text-muted-foreground"
                               />
-                              {format(parseISO(p.end_date), 'dd.MM.yy')}
+                              {format(
+                                parseISO(p.end_date),
+                                getDateFnsShortFormat(focus.getDashboardConfig().dateFormat),
+                              )}
                             </>
                           )}
                         </span>
@@ -1473,10 +1480,19 @@ function AddPrescriptionDialog({
               </p>
               <div className="grid grid-cols-2 gap-3">
                 <Field label={t('settings.startDate')}>
-                  <DateInput value={startDate} onChange={setStartDate} />
+                  <DateInput
+                    value={startDate}
+                    onChange={setStartDate}
+                    displayFormat={getDateFnsFormat(focus.getDashboardConfig().dateFormat)}
+                  />
                 </Field>
                 <Field label={t('settings.endDate')}>
-                  <DateInput value={endDate} onChange={setEndDate} clearable />
+                  <DateInput
+                    value={endDate}
+                    onChange={setEndDate}
+                    clearable
+                    displayFormat={getDateFnsFormat(focus.getDashboardConfig().dateFormat)}
+                  />
                 </Field>
               </div>
               <Field label={t('settings.durationDays')}>

--- a/modules/pill-tracker/frontend/src/today-widget.tsx
+++ b/modules/pill-tracker/frontend/src/today-widget.tsx
@@ -23,6 +23,7 @@ import {
   SelectValue,
 } from './components/ui/select'
 import { Separator } from './components/ui/separator'
+import { formatTime, nowInTimezone } from './lib/format-utils'
 import { cn } from './lib/utils'
 import type {
   DoseEntry,
@@ -256,8 +257,8 @@ function PillCalendar({ focus }: WidgetProps) {
   const [given, setGiven] = useState(0)
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
-  const [weekBase, setWeekBase] = useState(() => new Date())
-  const [selectedDate, setSelectedDate] = useState(() => new Date())
+  const [weekBase, setWeekBase] = useState(() => nowInTimezone(focus))
+  const [selectedDate, setSelectedDate] = useState(() => nowInTimezone(focus))
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('all')
   const [skipId, setSkipId] = useState<string | null>(null)
   const [skipReason, setSkipReason] = useState('')
@@ -265,7 +266,7 @@ function PillCalendar({ focus }: WidgetProps) {
 
   const containerRef = useRef<HTMLDivElement>(null)
   const firstPendingRef = useRef<HTMLDivElement>(null)
-  const today = useMemo(() => new Date(), [])
+  const today = useMemo(() => nowInTimezone(focus), [])
   const weekDays = useMemo(() => getWeekDays(weekBase), [weekBase])
 
   // Observe container width for responsive
@@ -517,7 +518,7 @@ function PillCalendar({ focus }: WidgetProps) {
               if (isFirstPending) firstPendingFound = true
               const isSkipping = skipId === dose.id
               const mealLabel = doseMealLabel(dose, t)
-              const time = dose.planned_at.slice(11, 16)
+              const time = formatTime(dose.planned_at, focus)
 
               return (
                 <div


### PR DESCRIPTION
## Summary
- Добавлен `format-utils.ts` с хелперами: `nowInTimezone()`, `formatTime()`, `getDateFnsFormat()`, `getDateFnsShortFormat()`
- **today-widget**: инициализация "сегодня" с учётом таймзоны дашборда, отображение времени в 12h/24h формате
- **settings**: даты рецептов форматируются через `getDashboardConfig().dateFormat`
- **date-input**: принимает `displayFormat` prop вместо жёсткого `dd.MM.yyyy`
- **backend**: `handleToday` принимает `?tz=` для timezone-aware fallback даты

## Test plan
- [ ] Сменить таймзону в Settings Panel → проверить что "сегодня" в pill-tracker соответствует
- [ ] Сменить формат даты (DD.MM.YYYY → YYYY-MM-DD) → проверить отображение в prescription card и DateInput
- [ ] Сменить формат времени (24h → 12h) → проверить отображение в dose card
- [ ] Проверить что навигация по неделям работает корректно с timezone

Fixes #50